### PR TITLE
Fix running magick convert on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For build commands please see package.json
 2. install `yarn` (https://yarnpkg.com/) and run `yarn install`
 3. create a `.env` file and copy contents of `.env.example`. Adjust env variables as you need
 4. When working on PTR change the `NW_USE_PTR=true` in `.env`
+5. install [ImageMagick](https://imagemagick.org/), which is required to convert images
 
 ## Extracting and importing game data
 

--- a/tools/importer/importImages.ts
+++ b/tools/importer/importImages.ts
@@ -38,7 +38,7 @@ export async function importImages({
     }
     const outDir = path.dirname(outFile)
     await mkdir(outDir, { recursive: true })
-    await spawn(`magick convert "${source}" -quality 85 "${outFile}"`, {
+    await spawn(`convert "${source}" -quality 85 "${outFile}"`, {
       shell: true,
       stdio: 'pipe',
       env: process.env,


### PR DESCRIPTION
On Ubunutu, `magick` is not available after installing `imagemagick`. Removing `magick` should not be an issue on Windows, because `convert` is added to PATH too.