### PR TITLE
feat: Add user profile avatars and full name

### DIFF
--- a/apps/pocketbase/pb_migrations/1759970980_updated_users.js
+++ b/apps/pocketbase/pb_migrations/1759970980_updated_users.js
@@ -1,0 +1,32 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "oauth2": {
+      "mappedFields": {
+        "avatarURL": "avatar",
+        "id": "name",
+        "username": "name"
+      }
+    }
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "oauth2": {
+      "mappedFields": {
+        "avatarURL": "",
+        "id": "",
+        "username": ""
+      }
+    }
+  }, collection)
+
+  return app.save(collection)
+})

--- a/apps/pocketbase/pb_migrations/1759972695_updated_users.js
+++ b/apps/pocketbase/pb_migrations/1759972695_updated_users.js
@@ -1,0 +1,48 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text4166911607",
+    "max": 0,
+    "min": 0,
+    "name": "username",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text70470110",
+    "max": 0,
+    "min": 0,
+    "name": "discord_id",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // remove field
+  collection.fields.removeById("text4166911607")
+
+  // remove field
+  collection.fields.removeById("text70470110")
+
+  return app.save(collection)
+})

--- a/apps/pocketbase/pb_migrations/1759972764_updated_users.js
+++ b/apps/pocketbase/pb_migrations/1759972764_updated_users.js
@@ -1,0 +1,30 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "oauth2": {
+      "mappedFields": {
+        "id": "discord_id",
+        "username": "username"
+      }
+    }
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "oauth2": {
+      "mappedFields": {
+        "id": "name",
+        "username": "name"
+      }
+    }
+  }, collection)
+
+  return app.save(collection)
+})

--- a/apps/pocketbase/pb_migrations/1759973189_updated_users.js
+++ b/apps/pocketbase/pb_migrations/1759973189_updated_users.js
@@ -1,0 +1,26 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // add field
+  collection.fields.addAt(10, new Field({
+    "exceptDomains": null,
+    "hidden": false,
+    "id": "url2190673250",
+    "name": "avatar_url",
+    "onlyDomains": null,
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "url"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // remove field
+  collection.fields.removeById("url2190673250")
+
+  return app.save(collection)
+})

--- a/apps/pocketbase/pb_migrations/1760070020_updated_users.js
+++ b/apps/pocketbase/pb_migrations/1760070020_updated_users.js
@@ -1,0 +1,20 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "viewRule": "@request.query.expand:isset = true"
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("_pb_users_auth_")
+
+  // update collection data
+  unmarshal({
+    "viewRule": "id = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/apps/web/app/auth/auth.component.html
+++ b/apps/web/app/auth/auth.component.html
@@ -6,7 +6,11 @@
   >
     <div class="avatar w-8 placeholder indicator" [class.avatar-online]="isOnline()">
       <div class="bg-neutral text-neutral-content w-8 rounded-full">
-        <span class="text-xl uppercase">{{ initials() }}</span>
+        @if (userAvatar(); as avatarUrl) {
+          <img [src]="avatarUrl" [alt]="userName()" class="rounded-full" />
+        } @else {
+          <span class="text-xl uppercase">{{ initials() }}</span>
+        }
       </div>
       @if (!isOnline()) {
         <span class="indicator-item badge badge-xs badge-error translate-x-0 translate-y-0 scale-75"></span>

--- a/apps/web/app/auth/auth.component.ts
+++ b/apps/web/app/auth/auth.component.ts
@@ -1,4 +1,5 @@
 import { CdkMenuModule } from '@angular/cdk/menu'
+import { CommonModule } from '@angular/common'
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core'
 import { RouterLink } from '@angular/router'
 import { BackendService } from '~/data/backend'
@@ -8,7 +9,7 @@ import { TooltipModule } from '~/ui/tooltip'
   standalone: true,
   selector: 'app-auth',
   templateUrl: './auth.component.html',
-  imports: [TooltipModule, CdkMenuModule, RouterLink  ],
+  imports: [CommonModule, TooltipModule, CdkMenuModule, RouterLink],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.hidden]': '!isEnabled()',
@@ -21,7 +22,8 @@ export class AuthComponent {
   protected isEnabled = this.backend.isEnabled
   protected isSignedIn = this.backend.isSignedIn
   protected userName = computed(() => this.backend.session()?.name)
-  protected initials = computed(() => this.userName().substring(0, 2))
+  protected initials = computed(() => this.userName()?.substring(0, 2) || '??')
+  protected userAvatar = computed(() => this.backend.session()?.avatarUrl || null)
 
   async signIn() {
     await this.backend.signIn()


### PR DESCRIPTION
Adds avatar and fullName fields to user profiles.

- 5 PocketBase migrations to add avatar and fullName to users collection
- Display user avatar in navbar
- Capture fullName during registration

Foundation for displaying user profiles in social features.