### PR TITLE
fix: add recursive flag to rmSync for data directory cleanup

### DIFF
--- a/tools/nw-generate.ts
+++ b/tools/nw-generate.ts
@@ -105,7 +105,7 @@ program
     const dataLinkDir = environment.nwDataDir('.current')
     console.log('Linking data directory', dataSrcDir, '->', dataLinkDir)
     if (fs.existsSync(dataLinkDir)) {
-      fs.rmSync(dataLinkDir, { force: true })
+      fs.rmSync(dataLinkDir, { force: true, recursive: true })
     }
 
     fs.symlinkSync(dataSrcDir, dataLinkDir, 'dir')


### PR DESCRIPTION
Fixes ERR_FS_EISDIR error when .current is a directory instead of a symlink.