### PR TITLE
Fix CompileRegexp to match ANY include pattern instead of ALL

### DIFF
--- a/tools/nwbt/nwfs/matcher.go
+++ b/tools/nwbt/nwfs/matcher.go
@@ -69,12 +69,15 @@ func CompileRegexp(patterns ...string) (func(string) bool, error) {
 				return false
 			}
 		}
+		if len(includes) == 0 {
+			return true
+		}
 		for _, matcher := range includes {
-			if !matcher.MatchString(path) {
-				return false
+			if matcher.MatchString(path) {
+				return true
 			}
 		}
-		return true
+		return false
 	}
 	return match, nil
 }

--- a/tools/nwbt/nwfs/matcher_test.go
+++ b/tools/nwbt/nwfs/matcher_test.go
@@ -88,6 +88,24 @@ func TestCompileRegexp(t *testing.T) {
 				"_baz":    false,
 			},
 		},
+		{
+			// multiple includes must match ANY pattern, not ALL of them
+			pattern: []string{"\\.baz$", "^foo/"},
+			samples: map[string]bool{
+				"foo/a.baz": true,
+				"bar/a.baz": true,
+				"foo/a.txt": true,
+				"bar/a.txt": false,
+			},
+		},
+		{
+			// excludes only: everything not excluded matches
+			pattern: []string{"!\\.tmp$"},
+			samples: map[string]bool{
+				"a.baz": true,
+				"a.tmp": false,
+			},
+		},
 	}
 	for _, test := range table {
 		match, err := nwfs.CompileRegexp(test.pattern...)


### PR DESCRIPTION
## Problem

`CompileRegexp` in `tools/nwbt/nwfs/matcher.go` requires a path to match **every** include pattern:

```go
for _, matcher := range includes {
    if !matcher.MatchString(path) {
        return false
    }
}
return true
```

Two include patterns targeting different files can never both match a single path, so **any call with 2 or more patterns silently matches nothing**.

This affects every command taking multiple `-e` arguments. For example:

```
nwbt unpack -e 'a/foo\..*' 'b/bar\..*'
```

returns zero files and reports no error, which looks identical to the files being absent from the archive. I hit this while batch-extracting textures and initially concluded the assets were missing.

## Fix

`CompileGlob`, directly above it in the same file, already implements the intended OR semantics. This change mirrors that logic exactly.

The `len(includes) == 0` guard is load-bearing: inverting the loop without it would make exclude-only patterns (`!foo`) match nothing, where the old AND loop happened to handle that case correctly by falling through to `return true`.

## Tests

`TestCompileRegexp` only ever passed a single pattern, which is why this went unnoticed. Added two cases:

- multiple includes — verifies ANY rather than ALL
- exclude-only — guards the `len(includes) == 0` path

Verified on `windows/amd64` via a cross-compiled test binary: the multiple-include case fails before this change and passes after. `TestCompileGlob` is unaffected.

Note: `TestNewUnpackedFS` in the same package fails both before and after this change on a clean checkout — unrelated and untouched here.