### PR TITLE
Split Oodle loader behind build tags so nwbt builds on non-Windows

### DIFF
--- a/tools/nwbt/utils/oodle.go
+++ b/tools/nwbt/utils/oodle.go
@@ -1,12 +1,8 @@
 package utils
 
 import (
-	"errors"
 	"os/exec"
 	"unsafe"
-
-	"github.com/ebitengine/purego"
-	"golang.org/x/sys/windows"
 )
 
 type Oodle interface {
@@ -40,22 +36,6 @@ func (it oodle) Info() string {
 	return "Oodle data compression library (Kraken/Leviathan), required for unpacking game archives\n" +
 		"info: https://www.radgametools.com/oodle.htm\n" +
 		"note: not available for standalone download, obtain from an existing game installation"
-}
-
-func (it *oodle) Load() error {
-	if it.decompress != nil {
-		return nil
-	}
-	p, ok := it.Check()
-	if !ok {
-		return errors.New("Oodle library not found")
-	}
-	handle, err := windows.LoadLibrary(p)
-	if err != nil {
-		return err
-	}
-	purego.RegisterLibFunc(&it.decompress, uintptr(handle), "OodleLZ_Decompress")
-	return nil
 }
 
 func (it *oodle) Decompress(input []byte, inSize int, output []byte, outSize int) (int, error) {

--- a/tools/nwbt/utils/oodle_other.go
+++ b/tools/nwbt/utils/oodle_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package utils
+
+import "errors"
+
+// The Oodle runtime ships only as a windows DLL (oo2core_*_win64.dll) and is
+// loaded through the win32 loader, so packed .pak archives cannot be read on
+// other platforms. Use an unpacked asset directory instead.
+func (it *oodle) Load() error {
+	return errors.New("Oodle is only supported on windows")
+}

--- a/tools/nwbt/utils/oodle_windows.go
+++ b/tools/nwbt/utils/oodle_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package utils
+
+import (
+	"errors"
+
+	"github.com/ebitengine/purego"
+	"golang.org/x/sys/windows"
+)
+
+func (it *oodle) Load() error {
+	if it.decompress != nil {
+		return nil
+	}
+	p, ok := it.Check()
+	if !ok {
+		return errors.New("Oodle library not found")
+	}
+	handle, err := windows.LoadLibrary(p)
+	if err != nil {
+		return err
+	}
+	purego.RegisterLibFunc(&it.decompress, uintptr(handle), "OodleLZ_Decompress")
+	return nil
+}


### PR DESCRIPTION
## Problem

`tools/nwbt/utils/oodle.go` imports `golang.org/x/sys/windows` unconditionally, so the whole `nwbt` module fails to build on any non-Windows host:

```
imports nw-buddy/tools/utils
imports golang.org/x/sys/windows: build constraints exclude all Go files
in golang.org/x/sys@v0.30.0/windows
```

This blocks `go build ./tools/nwbt/...`, `go vet` and `go test` for the `nwfs`/`pak` packages on Linux and macOS — including code paths that never touch Oodle. It also means the package tests can't run in a Linux CI container.

## Change

- `Load()` moves to `oodle_windows.go` (`//go:build windows`), implementation unchanged
- `oodle_other.go` (`//go:build !windows`) provides a stub returning an error
- `oodle.go` keeps the shared type, `Check()`, `Info()` and `Decompress()`, and no longer imports anything Windows-only

## What this does and does not do

It does **not** make extraction work off Windows. Oodle ships only as a Windows DLL, and the overwhelming majority of pak entries use zip method `0x0f`. In the build I measured, that was ~94% of entries, including most `.datasheet` and all `.dynamicslice` files.

What it enables is building and running the tools on other platforms against an **unpacked** asset directory, where `nwfs.NewUnpackedArchive` reads plain files and never calls into Oodle. So the workflow of unpacking on Windows and then serving/developing on Linux works without a patched tree.

Reading a method `0x0f` entry on a non-Windows build now fails at runtime with `Oodle is only supported on windows` instead of failing to compile.

## Verification

- `go build ./tools/nwbt/...` — passes on Linux
- `GOOS=windows GOARCH=amd64 go build ./tools/nwbt` — passes, Windows path unchanged
- `go vet ./tools/nwbt/utils/` — clean
- `nwbt vet` runs to completion on Linux against a game directory
- a stored (method `0x00`) entry still reads correctly via `nwbt cat`

CRLF line endings preserved to match the existing file, so the diff stays minimal.